### PR TITLE
Make compile on 0.7.0, Remove string struct, and update older code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 Implements common string operations such as substring searching.
 
+Note: Most of these functions are in std.mem.
+
 Inspired by this repo: https://github.com/clownpriest/strings/
 
 To test:

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,15 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    const mode = b.standardReleaseOptions();
+    const lib = b.addStaticLibrary("string", "string.zig");
+    lib.setBuildMode(mode);
+    lib.install();
+
+    var string_tests = b.addTest("string.zig");
+    string_tests.setBuildMode(mode);
+
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&string_tests.step);
+}

--- a/readme.zig
+++ b/readme.zig
@@ -1,16 +1,3 @@
-
-Implements common string operations such as substring searching.
-
-Inspired by this repo: https://github.com/clownpriest/strings/
-
-To test:
-```bash
-cd zig-string
-zig test string.zig
-```
-
-Basic Usage:
-```zig
 const std = @import("std");
 const print = std.debug.print;
 const string = @import("string.zig");
@@ -32,10 +19,3 @@ pub fn main() !void {
         print("{}\n", .{ val });
     }
 }
-```
-
-This example can be run with:
-```bash
-cd zig-string
-zig run readme.zig
-```

--- a/string.zig
+++ b/string.zig
@@ -36,7 +36,7 @@ fn longestPrefixSuffix(allocator: *Allocator, buffer: []const u8, pattern: []con
 
 /// Return the index of the first match for a given pattern or null.
 /// Uses `allocator` for table generation, allocating the length of `pattern`.
-pub fn findSubString(allocator: *Allocator, buffer: []const u8, pattern: []const u8) !?usize {
+pub fn findSubstring(allocator: *Allocator, buffer: []const u8, pattern: []const u8) !?usize {
     if (isEmpty(buffer) or pattern.len < 1 or pattern.len > buffer.len) {
         return null;
     }
@@ -68,7 +68,7 @@ pub fn findSubString(allocator: *Allocator, buffer: []const u8, pattern: []const
 /// Uses Knuth-Morris-Pratt Algorithm for []u8 searching
 /// https://en.wikipedia.org/wiki/Knuth–Morris–Pratt_algorithm
 /// Caller owns the returned memory
-pub fn findSubStringIndices(allocator: *Allocator, buffer: []const u8, pattern: []const u8) ![]usize {
+pub fn findSubstringIndices(allocator: *Allocator, buffer: []const u8, pattern: []const u8) ![]usize {
     var indices = ArrayList(usize).init(allocator);
     defer indices.deinit();
     if (isEmpty(buffer) or pattern.len < 1 or pattern.len > buffer.len) {
@@ -100,7 +100,7 @@ pub fn findSubStringIndices(allocator: *Allocator, buffer: []const u8, pattern: 
 }
 
 pub fn contains(allocator: *Allocator, buffer: []const u8, pattern: []const u8) !bool {
-    return null != try findSubString(allocator, buffer, pattern);
+    return null != try findSubstring(allocator, buffer, pattern);
 }
 
 pub fn toSlice(buffer: []const u8) []u8 {
@@ -145,7 +145,7 @@ pub fn replace(buffer: *[]u8, allocator: *Allocator, old: []const u8, new: []con
         return;
     }
 
-    var matches = try buffer.findSubStringIndices(allocator, old);
+    var matches = try buffer.findSubstringIndices(allocator, old);
     defer allocator.free(matches);
     if (matches.len < 1) {
         return;
@@ -173,7 +173,7 @@ pub fn replace(buffer: *[]u8, allocator: *Allocator, old: []const u8, new: []con
 }
 
 pub fn count(buffer: []const u8, allocator: *Allocator, pattern: []const u8) !usize {
-    var matches = try buffer.findSubStringIndices(allocator, pattern);
+    var matches = try buffer.findSubstringIndices(allocator, pattern);
     return matches.len;
 }
 
@@ -211,7 +211,7 @@ test "eql" {
     testing.expect(mem.eql(u8, s, "hello world"));
 }
 
-test "findSubStringIndices" {
+test "findSubstringIndices" {
     var buf: [1024]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
     const lit = "Mississippi";
@@ -219,23 +219,23 @@ test "findSubStringIndices" {
     mem.copy(u8, s, lit);
     defer allocator.free(s);
 
-    const m1 = try findSubStringIndices(testing.allocator, s, "i");
+    const m1 = try findSubstringIndices(testing.allocator, s, "i");
     defer testing.allocator.free(m1);
     print("{}\n", .{m1});
     testing.expect(mem.eql(usize, m1, &[_]usize{ 1, 4, 7, 10 }));
 
-    // const m2 = try s.findSubStringIndices(allocator, "iss");
+    // const m2 = try s.findSubstringIndices(allocator, "iss");
     // testing.expect(mem.eql(usize, m2, [_]usize{ 1, 4 }));
 
-    // const m3 = try s.findSubStringIndices(allocator, "z");
+    // const m3 = try s.findSubstringIndices(allocator, "z");
     // testing.expect(mem.eql(usize, m3, [_]usize{}));
 
-    // const m4 = try s.findSubStringIndices(allocator, "Mississippi");
+    // const m4 = try s.findSubstringIndices(allocator, "Mississippi");
     // testing.expect(mem.eql(usize, m4, [_]usize{0}));
 
     // var s2 = try []u8.init(allocator, "的中对不起我的中文不好");
     // defer s2.deinit();
-    // const m5 = try s2.findSubStringIndices(allocator, "的中");
+    // const m5 = try s2.findSubstringIndices(allocator, "的中");
     // testing.expect(mem.eql(usize, m5, [_]usize{ 0, 18 }));
 }
 
@@ -253,159 +253,159 @@ test ".contains" {
     testing.expect(m4);
 }
 
-test ".toSlice" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "hello world");
-    defer s.deinit();
-    testing.expect(mem.eql(u8, "hello world", s.toSlice()));
-}
+// test ".toSlice" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "hello world");
+//     defer s.deinit();
+//     testing.expect(mem.eql(u8, "hello world", s.toSlice()));
+// }
 
-test ".toSliceConst" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "hello world");
-    defer s.deinit();
-    testing.expect(mem.eql(u8, "hello world", s.toSliceConst()));
-}
+// test ".toSliceConst" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "hello world");
+//     defer s.deinit();
+//     testing.expect(mem.eql(u8, "hello world", s.toSliceConst()));
+// }
 
-test ".trim" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, " foo\n ");
-    defer s.deinit();
-    try s.trim(" \n");
-    testing.expectEqualSlices(u8, "foo", s.toSliceConst());
-    testing.expect(3 == s.len);
-    try s.trim(" \n");
-    testing.expectEqualSlices(u8, "foo", s.toSliceConst());
-}
+// test ".trim" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, " foo\n ");
+//     defer s.deinit();
+//     try s.trim(" \n");
+//     testing.expectEqualSlices(u8, "foo", s.toSliceConst());
+//     testing.expect(3 == s.len);
+//     try s.trim(" \n");
+//     testing.expectEqualSlices(u8, "foo", s.toSliceConst());
+// }
 
-test ".trimLeft" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, " foo\n ");
-    defer s.deinit();
-    try s.trimLeft(" \n");
-    testing.expectEqualSlices(u8, "foo\n ", s.toSliceConst());
-}
+// test ".trimLeft" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, " foo\n ");
+//     defer s.deinit();
+//     try s.trimLeft(" \n");
+//     testing.expectEqualSlices(u8, "foo\n ", s.toSliceConst());
+// }
 
-test ".trimRight" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, " foo\n ");
-    defer s.deinit();
-    try s.trimRight(" \n");
-    testing.expectEqualSlices(u8, " foo", s.toSliceConst());
-}
+// test ".trimRight" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, " foo\n ");
+//     defer s.deinit();
+//     try s.trimRight(" \n");
+//     testing.expectEqualSlices(u8, " foo", s.toSliceConst());
+// }
 
-test ".split" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "abc|def||ghi");
-    defer s.deinit();
+// test ".split" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "abc|def||ghi");
+//     defer s.deinit();
 
-    // All of these tests are from std/mem.zig
-    var it = s.split("|");
-    testing.expect(mem.eql(u8, it.next().?, "abc"));
-    testing.expect(mem.eql(u8, it.next().?, "def"));
-    testing.expect(mem.eql(u8, it.next().?, ""));
-    testing.expect(mem.eql(u8, it.next().?, "ghi"));
-    testing.expect(it.next() == null);
+//     // All of these tests are from std/mem.zig
+//     var it = s.split("|");
+//     testing.expect(mem.eql(u8, it.next().?, "abc"));
+//     testing.expect(mem.eql(u8, it.next().?, "def"));
+//     testing.expect(mem.eql(u8, it.next().?, ""));
+//     testing.expect(mem.eql(u8, it.next().?, "ghi"));
+//     testing.expect(it.next() == null);
 
-    try s.buffer.replaceContents("");
-    it = s.split("|");
-    testing.expect(mem.eql(u8, it.next().?, ""));
-    testing.expect(it.next() == null);
+//     try s.buffer.replaceContents("");
+//     it = s.split("|");
+//     testing.expect(mem.eql(u8, it.next().?, ""));
+//     testing.expect(it.next() == null);
 
-    try s.buffer.replaceContents("|");
-    it = s.split("|");
-    testing.expect(mem.eql(u8, it.next().?, ""));
-    testing.expect(mem.eql(u8, it.next().?, ""));
-    testing.expect(it.next() == null);
-}
+//     try s.buffer.replaceContents("|");
+//     it = s.split("|");
+//     testing.expect(mem.eql(u8, it.next().?, ""));
+//     testing.expect(mem.eql(u8, it.next().?, ""));
+//     testing.expect(it.next() == null);
+// }
 
-test ".replace" {
-    var buf: [1024]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "Mississippi");
-    defer s.deinit();
-    try s.replace(allocator, "iss", "e");
-    testing.expectEqualSlices(u8, "Meeippi", s.toSliceConst());
+// test ".replace" {
+//     var buf: [1024]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "Mississippi");
+//     defer s.deinit();
+//     try s.replace(allocator, "iss", "e");
+//     testing.expectEqualSlices(u8, "Meeippi", s.toSliceConst());
 
-    try s.buffer.replaceContents("Mississippi");
-    try s.replace(allocator, "iss", "issi");
-    testing.expectEqualSlices(u8, "Missiissiippi", s.toSliceConst());
+//     try s.buffer.replaceContents("Mississippi");
+//     try s.replace(allocator, "iss", "issi");
+//     testing.expectEqualSlices(u8, "Missiissiippi", s.toSliceConst());
 
-    try s.buffer.replaceContents("Mississippi");
-    try s.replace(allocator, "i", "a");
-    testing.expectEqualSlices(u8, "Massassappa", s.toSliceConst());
+//     try s.buffer.replaceContents("Mississippi");
+//     try s.replace(allocator, "i", "a");
+//     testing.expectEqualSlices(u8, "Massassappa", s.toSliceConst());
 
-    try s.buffer.replaceContents("Mississippi");
-    try s.replace(allocator, "iss", "");
-    testing.expectEqualSlices(u8, "Mippi", s.toSliceConst());
+//     try s.buffer.replaceContents("Mississippi");
+//     try s.replace(allocator, "iss", "");
+//     testing.expectEqualSlices(u8, "Mippi", s.toSliceConst());
 
-    try s.buffer.replaceContents("Mississippi");
-    try s.replace(allocator, s.toSliceConst(), "Foo");
-    testing.expectEqualSlices(u8, "Foo", s.toSliceConst());
-}
+//     try s.buffer.replaceContents("Mississippi");
+//     try s.replace(allocator, s.toSliceConst(), "Foo");
+//     testing.expectEqualSlices(u8, "Foo", s.toSliceConst());
+// }
 
-test ".count" {
-    var buf: [1024]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "Mississippi");
-    defer s.deinit();
-    const c1 = try s.count(allocator, "i");
-    testing.expect(c1 == 4);
+// test ".count" {
+//     var buf: [1024]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "Mississippi");
+//     defer s.deinit();
+//     const c1 = try s.count(allocator, "i");
+//     testing.expect(c1 == 4);
 
-    const c2 = try s.count(allocator, "M");
-    testing.expect(c2 == 1);
+//     const c2 = try s.count(allocator, "M");
+//     testing.expect(c2 == 1);
 
-    const c3 = try s.count(allocator, "abc");
-    testing.expect(c3 == 0);
+//     const c3 = try s.count(allocator, "abc");
+//     testing.expect(c3 == 0);
 
-    const c4 = try s.count(allocator, "iss");
-    testing.expect(c4 == 2);
-}
+//     const c4 = try s.count(allocator, "iss");
+//     testing.expect(c4 == 2);
+// }
 
-test ".toLower" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "ABCDEF");
-    defer s.deinit();
-    s.toLower();
-    testing.expectEqualSlices(u8, "abcdef", s.toSliceConst());
+// test ".toLower" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "ABCDEF");
+//     defer s.deinit();
+//     s.toLower();
+//     testing.expectEqualSlices(u8, "abcdef", s.toSliceConst());
 
-    try s.buffer.replaceContents("的ABcdEF中");
-    s.toLower();
-    testing.expectEqualSlices(u8, "的abcdef中", s.toSliceConst());
+//     try s.buffer.replaceContents("的ABcdEF中");
+//     s.toLower();
+//     testing.expectEqualSlices(u8, "的abcdef中", s.toSliceConst());
 
-    try s.buffer.replaceContents("AB的cd中EF");
-    s.toLower();
-    testing.expectEqualSlices(u8, "ab的cd中ef", s.toSliceConst());
-}
+//     try s.buffer.replaceContents("AB的cd中EF");
+//     s.toLower();
+//     testing.expectEqualSlices(u8, "ab的cd中ef", s.toSliceConst());
+// }
 
-test ".toUpper" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "abcdef");
-    defer s.deinit();
-    s.toUpper();
-    testing.expectEqualSlices(u8, "ABCDEF", s.toSliceConst());
+// test ".toUpper" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "abcdef");
+//     defer s.deinit();
+//     s.toUpper();
+//     testing.expectEqualSlices(u8, "ABCDEF", s.toSliceConst());
     
-    try s.buffer.replaceContents("的abCDef中");
-    s.toUpper();
-    testing.expectEqualSlices(u8, "的ABCDEF中", s.toSliceConst());
+//     try s.buffer.replaceContents("的abCDef中");
+//     s.toUpper();
+//     testing.expectEqualSlices(u8, "的ABCDEF中", s.toSliceConst());
 
-    try s.buffer.replaceContents("ab的CD中ef");
-    s.toUpper();
-    testing.expectEqualSlices(u8, "AB的CD中EF", s.toSliceConst());
-}
+//     try s.buffer.replaceContents("ab的CD中ef");
+//     s.toUpper();
+//     testing.expectEqualSlices(u8, "AB的CD中EF", s.toSliceConst());
+// }
 
-test ".ptr" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try []u8.init(allocator, "abcdef");
-    defer s.deinit();
-    testing.expect(mem.eql(u8, mem.toSliceConst(u8, s.ptr()), s.toSliceConst()));
-}
+// test ".ptr" {
+//     var buf: [256]u8 = undefined;
+//     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
+//     var s = try []u8.init(allocator, "abcdef");
+//     defer s.deinit();
+//     testing.expect(mem.eql(u8, mem.toSliceConst(u8, s.ptr()), s.toSliceConst()));
+// }

--- a/string.zig
+++ b/string.zig
@@ -117,7 +117,7 @@ pub fn replace(allocator: *Allocator, buffer: *[]u8, old: []const u8, new: []con
         return;
     }
 
-    var matches = try buffer.findSubstringIndices(allocator, old);
+    var matches = try findSubstringIndices(allocator, buffer.*, old);
     defer allocator.free(matches);
     if (matches.len < 1) {
         return;
@@ -128,7 +128,7 @@ pub fn replace(allocator: *Allocator, buffer: *[]u8, old: []const u8, new: []con
     var orig_index: usize = 0;
     for (matches) |match_index| {
         while (orig_index < match_index) {
-            try new_contents.append(buffer.at(orig_index));
+            try new_contents.append(buffer[orig_index]);
             orig_index += 1;
         }
         orig_index = match_index + old.len;
@@ -218,8 +218,9 @@ test "contains" {
 }
 
 test "replace" {
-    var s = "Mississippi";
-
+    var s: *[]u8 = undefined;
+    mem.copy(u8, s.*, "Mississippi");
+    
     try replace(testing.allocator, s, "iss", "e");
     expectEqualSlices(u8, "Meeippi", s.toSliceConst());
 

--- a/string.zig
+++ b/string.zig
@@ -1,15 +1,12 @@
 const std = @import("std");
 const mem = std.mem;
 const debug = std.debug;
-const ascii = std.ascii;
 const Allocator = mem.Allocator;
 const ArrayList = std.ArrayList;
 
 /// Alias for `buffer.len == 0`
 pub fn isEmpty(buffer: anytype) bool {
     // TODO: case match nullables
-    // Can't use Buffer.isNull because Buffer maintains a null byte at the
-    // end. (e.g., []u8 of "" in a Buffer is not null)
     return buffer.len == 0;
 }
 

--- a/string.zig
+++ b/string.zig
@@ -148,21 +148,21 @@ pub fn replace(
     var new_contents = ArrayList(u8).init(allocator);
     defer new_contents.deinit();
 
-    var orig_index: usize = 0;
-    for (matches) |match_index| {
-        while (orig_index < match_index) {
-            try new_contents.append(buffer.*[orig_index]);
-            orig_index += 1;
+    var original: usize = 0;
+    for (matches) |match| {
+        while (original < match) {
+            try new_contents.append(buffer.*[original]);
+            original += 1;
         }
-        orig_index = match_index + old.len;
+        original = match + old.len;
         for (new) |val| {
             try new_contents.append(val);
         }
     }
     // Append end of string if match does not end original string
-    while (orig_index < buffer.len) {
-        try new_contents.append(buffer.*[orig_index]);
-        orig_index += 1;
+    while (original < buffer.len) {
+        try new_contents.append(buffer.*[original]);
+        original += 1;
     }
 }
 
@@ -174,20 +174,15 @@ const span = mem.span;
 test "isEmpty" {
     var s = "hello";
     expect(!isEmpty(s));
+    var s1 = "";
+    expect(isEmpty(s1));
 }
 
-test "eql" {
-    var s = try testing.allocator.alloc(u8, 11);
-    defer testing.allocator.free(s);
-    
-    mem.copy(u8, s, "hello world");
-
-    expect(mem.eql(u8, s, "hello world"));
-}
 
 test "longestPrefixSuffix" {
     const lps = try longestPrefixSuffix(testing.allocator, "issi");
     defer testing.allocator.free(lps);
+    expect(mem.eql(usize, lps, &[_]usize{ 0, 0, 0, 1 }));
 }
 
 test "findSubstringIndices" {
@@ -245,7 +240,7 @@ test "replace" {
     mem.copy(u8, s, "Mississippi");
 
     try replace(testing.allocator, &s, "iss", "issi");
-    expect(mem.eql(u8, "Missiissiippi", s));
+    expect(mem.eql(u8, "Missiissiippi", span(s)));
     mem.copy(u8, s, "Mississippi");
 
     try replace(testing.allocator, &s, "i", "a");

--- a/string.zig
+++ b/string.zig
@@ -2,347 +2,261 @@ const std = @import("std");
 const mem = std.mem;
 const ascii = std.ascii;
 const Allocator = mem.Allocator;
-const Buffer = std.Buffer;
 const ArrayList = std.ArrayList;
-const testing = std.testing;
 
-pub const String = struct {
-    buffer: Buffer,
 
-    pub fn init(allocator: *Allocator, m: []const u8) !String {
-        return String{ .buffer = try Buffer.init(allocator, m) };
-    }
+pub fn isEmpty(buffer: []const u8) bool {
+    // Can't use Buffer.isNull because Buffer maintains a null byte at the
+    // end. (e.g., []u8 of "" in a Buffer is not null)
+    return buffer.len == 0;
+}
 
-    pub fn deinit(self: *String) void {
-        self.buffer.deinit();
-    }
-
-    pub fn startsWith(self: *const String, m: []const u8) bool {
-        return self.buffer.startsWith(m);
-    }
-
-    pub fn endsWith(self: *const String, m: []const u8) bool {
-        return self.buffer.endsWith(m);
-    }
-
-    pub fn isEmpty(self: *const String) bool {
-        // Can't use Buffer.isNull because Buffer maintains a null byte at the
-        // end. (e.g., string of "" in a Buffer is not null)
-        return self.buffer.len() == 0;
-    }
-
-    pub fn len(self: *const String) usize {
-        return self.buffer.len();
-    }
-
-    pub fn append(self: *String, m: []const u8) !void {
-        try self.buffer.append(m);
-    }
-
-    pub fn eql(self: *const String, m: []const u8) bool {
-        return self.buffer.eql(m);
-    }
-
-    pub fn reverse(self: *String) void {
-        if (self.len() <= 1) {
-            return;
-        }
-        var i: usize = 0;
-        var j: usize = self.len() - 1;
-        while (i < j) {
-            var temp = self.at(i);
-            self.buffer.list.set(i, self.buffer.list.at(j));
-            self.buffer.list.set(j, temp);
-            i += 1;
-            j -= 1;
-        }
-    }
-
-    pub fn at(self: *const String, i: usize) u8 {
-        return self.buffer.list.at(i);
-    }
-
-    /// Caller owns the returned memory
-    fn computeLongestPrefixSuffixArray(self: *const String, allocator: *Allocator, pattern: []const u8) ![]usize {
-        var m = pattern.len;
-        var lps = ArrayList(usize).init(allocator);
-        defer lps.deinit();
-        var size: usize = 0;
-        while (size < m) : (size += 1) {
-            try lps.append(0);
-        }
-        // Left and right positions going through the pattern
-        var left: usize = 0;
-        var right: usize = 1;
-        while (right < m) {
-            if (pattern[right] == pattern[left]) {
-                lps.set(right, left + 1);
-                left += 1;
+/// Caller owns the returned memory
+fn longestPrefixSuffix(allocator: *Allocator, buffer: []const u8, pattern: []const u8) ![]usize {
+    var lps = try allocator.alloc(usize, pattern.len);    
+    // Left and right positions going through the pattern
+    var left: usize = 0;
+    var right: usize = 1;
+    while (right < pattern.len) {
+        if (pattern[right] == pattern[left]) {
+            lps[right] = left + 1;
+            left += 1;
+            right += 1;
+        } else {
+            if (left != 0) {
+                left = lps[left - 1];
+            } else {
+                lps[right] = 0;
                 right += 1;
-            } else {
-                if (left != 0) {
-                    left = lps.at(left - 1);
-                } else {
-                    lps.set(right, 0);
-                    right += 1;
-                }
             }
         }
-        return lps.toOwnedSlice();
+    }
+    return lps;
+}
+
+/// Return the index of the first match for a given pattern or null.
+/// Uses `allocator` for table generation, allocating the length of `pattern`.
+pub fn findSubString(allocator: *Allocator, buffer: []const u8, pattern: []const u8) !?usize {
+    if (isEmpty(buffer) or pattern.len < 1 or pattern.len > buffer.len) {
+        return null;
     }
 
-    /// Return an array of indices containing substring matches for a given pattern
-    /// Uses Knuth-Morris-Pratt Algorithm for string searching
-    /// https://en.wikipedia.org/wiki/Knuth–Morris–Pratt_algorithm
-    /// Caller owns the returned memory
-    pub fn findSubstringIndices(self: *const String, allocator: *Allocator, pattern: []const u8) ![]usize {
-        var indices = ArrayList(usize).init(allocator);
-        defer indices.deinit();
-        if (self.isEmpty() or pattern.len < 1 or pattern.len > self.len()) {
-            return indices.toSlice();
-        }
+    var lps = try longestPrefixSuffix(allocator, buffer, pattern);
+    defer allocator.free(lps);
 
-        var lps = try self.computeLongestPrefixSuffixArray(allocator, pattern);
-        defer allocator.free(lps);
-
-        var str_index: usize = 0;
-        var pat_index: usize = 0;
-        while (str_index < self.len() and pat_index < pattern.len) {
-            if (self.at(str_index) == pattern[pat_index]) {
+    var str_index: usize = 0;
+    var pat_index: usize = 0;
+    while (str_index < buffer.len and pat_index < pattern.len) {
+        if (buffer[str_index] == pattern[pat_index]) {
+            str_index += 1;
+            pat_index += 1;
+        } else {
+            if (pat_index != 0) {
+                pat_index = lps[pat_index - 1];
+            } else {
                 str_index += 1;
-                pat_index += 1;
+            }
+        }
+        if (pat_index == pattern.len) {
+            return str_index - pattern.len;
+        }
+    }
+    return null;
+}
+
+/// Return an array of indices containing sub[]u8 matches for a given pattern
+/// Uses Knuth-Morris-Pratt Algorithm for []u8 searching
+/// https://en.wikipedia.org/wiki/Knuth–Morris–Pratt_algorithm
+/// Caller owns the returned memory
+pub fn findSubStringIndices(allocator: *Allocator, buffer: []const u8, pattern: []const u8) ![]usize {
+    var indices = ArrayList(usize).init(allocator);
+    defer indices.deinit();
+    if (isEmpty(buffer) or pattern.len < 1 or pattern.len > buffer.len) {
+        return indices.items;
+    }
+
+    var lps = try longestPrefixSuffix(allocator, buffer, pattern);
+    defer allocator.free(lps);
+
+    var str_index: usize = 0;
+    var pat_index: usize = 0;
+    while (str_index < buffer.len and pat_index < pattern.len) {
+        if (buffer[str_index] == pattern[pat_index]) {
+            str_index += 1;
+            pat_index += 1;
+        } else {
+            if (pat_index != 0) {
+                pat_index = lps[pat_index - 1];
             } else {
-                if (pat_index != 0) {
-                    pat_index = lps[pat_index - 1];
-                } else {
-                    str_index += 1;
-                }
-            }
-            if (pat_index == pattern.len) {
-                try indices.append(str_index - pattern.len);
-                pat_index = 0;
+                str_index += 1;
             }
         }
-        return indices.toOwnedSlice();
-    }
-
-    pub fn contains(self: *const String, allocator: *Allocator, pattern: []const u8) !bool {
-        var matches = try self.findSubstringIndices(allocator, pattern);
-        defer allocator.free(matches);
-        return matches.len > 0;
-    }
-
-    pub fn toSlice(self: *const String) []u8 {
-        return self.buffer.toSlice();
-    }
-
-    pub fn toSliceConst(self: *const String) []const u8 {
-        return self.buffer.toSliceConst();
-    }
-
-    pub fn trim(self: *String, trim_pattern: []const u8) !void {
-        var trimmed_str = mem.trim(u8, self.toSliceConst(), trim_pattern);
-        try self.setTrimmedStr(trimmed_str);
-    }
-
-    pub fn trimLeft(self: *String, trim_pattern: []const u8) !void {
-        const trimmed_str = mem.trimLeft(u8, self.toSliceConst(), trim_pattern);
-        try self.setTrimmedStr(trimmed_str);
-    }
-
-    pub fn trimRight(self: *String, trim_pattern: []const u8) !void {
-        const trimmed_str = mem.trimRight(u8, self.toSliceConst(), trim_pattern);
-        try self.setTrimmedStr(trimmed_str);
-    }
-
-    fn setTrimmedStr(self: *String, trimmed_str: []const u8) !void {
-        const m = trimmed_str.len;
-        std.debug.assert(self.len() >= m); // this should always be true
-        for (trimmed_str) |v, i| {
-            self.buffer.list.set(i, v);
+        if (pat_index == pattern.len) {
+            try indices.append(str_index - pattern.len);
+            pat_index = 0;
         }
-        try self.buffer.resize(m);
+    }
+    return indices.toOwnedSlice();
+}
+
+pub fn contains(allocator: *Allocator, buffer: []const u8, pattern: []const u8) !bool {
+    return null != try findSubString(allocator, buffer, pattern);
+}
+
+pub fn toSlice(buffer: []const u8) []u8 {
+    return buffer.toSlice();
+}
+
+pub fn toSliceConst(buffer: []const u8) []const u8 {
+    return buffer.toSliceConst();
+}
+
+pub fn trim(buffer: *[]u8, trim_pattern: []const u8) !void {
+    var trimmed_str = mem.trim(u8, buffer.toSliceConst(), trim_pattern);
+    try buffer.setTrimmedStr(trimmed_str);
+}
+
+pub fn trimLeft(buffer: *[]u8, trim_pattern: []const u8) !void {
+    const trimmed_str = mem.trimLeft(u8, buffer.toSliceConst(), trim_pattern);
+    try buffer.setTrimmedStr(trimmed_str);
+}
+
+pub fn trimRight(buffer: *[]u8, trim_pattern: []const u8) !void {
+    const trimmed_str = mem.trimRight(u8, buffer.toSliceConst(), trim_pattern);
+    try buffer.setTrimmedStr(trimmed_str);
+}
+
+fn setTrimmedStr(buffer: *[]u8, trimmed_str: []const u8) !void {
+    const m = trimmed_str.len;
+    std.debug.assert(buffer.len >= m); // this should always be true
+    for (trimmed_str) |v, i| {
+        buffer.list.set(i, v);
+    }
+    try buffer.resize(m);
+}
+
+pub fn split(buffer: []const u8, delimiter: []const u8) mem.SplitIterator {
+    return mem.separate(buffer.toSliceConst(), delimiter);
+}
+
+/// Replaces all occurrences of sub[]u8 `old` replaced with `new` in place
+pub fn replace(buffer: *[]u8, allocator: *Allocator, old: []const u8, new: []const u8) !void {
+    if (buffer.len < 1 or old.len < 1) {
+        return;
     }
 
-    pub fn split(self: *const String, delimiter: []const u8) mem.SplitIterator {
-        return mem.separate(self.toSliceConst(), delimiter);
+    var matches = try buffer.findSubStringIndices(allocator, old);
+    defer allocator.free(matches);
+    if (matches.len < 1) {
+        return;
     }
+    var new_contents = ArrayList(u8).init(allocator);
+    defer new_contents.deinit();
 
-    /// Replaces all occurrences of substring `old` replaced with `new` in place
-    pub fn replace(self: *String, allocator: *Allocator, old: []const u8, new: []const u8) !void {
-        if (self.len() < 1 or old.len < 1) {
-            return;
-        }
-
-        var matches = try self.findSubstringIndices(allocator, old);
-        defer allocator.free(matches);
-        if (matches.len < 1) {
-            return;
-        }
-        var new_contents = ArrayList(u8).init(allocator);
-        defer new_contents.deinit();
-
-        var orig_index: usize = 0;
-        for (matches) |match_index| {
-            while (orig_index < match_index) {
-                try new_contents.append(self.at(orig_index));
-                orig_index += 1;
-            }
-            orig_index = match_index + old.len;
-            for (new) |val| {
-                try new_contents.append(val);
-            }
-        }
-        // Append end of string if match does not end original string
-        while (orig_index < self.len()) {
-            try new_contents.append(self.at(orig_index));
+    var orig_index: usize = 0;
+    for (matches) |match_index| {
+        while (orig_index < match_index) {
+            try new_contents.append(buffer.at(orig_index));
             orig_index += 1;
         }
-        try self.buffer.replaceContents(new_contents.toSliceConst());
-    }
-
-    pub fn count(self: *const String, allocator: *Allocator, pattern: []const u8) !usize {
-        var matches = try self.findSubstringIndices(allocator, pattern);
-        return matches.len;
-    }
-
-    /// Only makes ASCII characters lowercase
-    pub fn toLower(self: *String) void {
-        for (self.toSlice()) |*c| {
-            c.* = ascii.toLower(c.*);
+        orig_index = match_index + old.len;
+        for (new) |val| {
+            try new_contents.append(val);
         }
     }
-
-    /// Only makes ASCII characters uppercase
-    pub fn toUpper(self: *String) void {
-        for (self.toSlice()) |*c| {
-            c.* = ascii.toUpper(c.*);
-        }
+    // Append end of []u8 if match does not end original []u8
+    while (orig_index < buffer.len) {
+        try new_contents.append(buffer.at(orig_index));
+        orig_index += 1;
     }
+    try buffer.replaceContents(new_contents.toSliceConst());
+}
 
-    pub fn ptr(self: *const String) [*]u8 {
-        return self.buffer.ptr();
+pub fn count(buffer: []const u8, allocator: *Allocator, pattern: []const u8) !usize {
+    var matches = try buffer.findSubStringIndices(allocator, pattern);
+    return matches.len;
+}
+
+/// Only makes ASCII characters lowercase
+pub fn toLower(buffer: *[]u8) void {
+    for (buffer.toSlice()) |*c| {
+        c.* = ascii.toLower(c.*);
     }
-};
-
-test ".startsWith" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "hello world");
-    defer s.deinit();
-
-    testing.expect(s.startsWith("hel"));
 }
 
-test ".endsWith" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "hello world");
-    defer s.deinit();
-
-    testing.expect(s.endsWith("orld"));
+/// Only makes ASCII characters uppercase
+pub fn toUpper(buffer: *[]u8) void {
+    for (buffer.toSlice()) |*c| {
+        c.* = ascii.toUpper(c.*);
+    }
 }
 
-test ".isEmpty" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "");
-    defer s.deinit();
 
-    testing.expect(s.isEmpty());
-    try s.append("hello");
-    std.testing.expect(!s.isEmpty());
+const testing = std.testing;
+const print = std.debug.print;
+
+test "isEmpty" {
+    var s = "hello";
+    std.testing.expect(!isEmpty(s));
 }
 
-test ".len" {
+test "eql" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "");
-    defer s.deinit();
+    var s = try allocator.alloc(u8, 11);
+    defer allocator.free(s);
+    
+    mem.copy(u8, s, "hello world");
 
-    testing.expect(s.len() == 0);
-    try s.append("hello");
-    std.testing.expect(s.len() == 5);
+    testing.expect(mem.eql(u8, s, "hello world"));
 }
 
-test ".eql" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "hello world");
-    defer s.deinit();
-
-    testing.expect(s.eql("hello world"));
-}
-
-test ".reverse" {
-    var buf: [256]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "");
-    defer s.deinit();
-
-    s.reverse();
-    testing.expect(s.eql(""));
-
-    try s.append("h");
-    s.reverse();
-    testing.expect(s.eql("h"));
-
-    try s.append("e");
-    s.reverse();
-    testing.expect(s.eql("eh"));
-
-    try s.buffer.replaceContents("hello");
-    s.reverse();
-    testing.expect(s.eql("olleh"));
-}
-
-test ".findSubstringIndices" {
+test "findSubStringIndices" {
     var buf: [1024]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "Mississippi");
-    defer s.deinit();
+    const lit = "Mississippi";
+    var s = try allocator.alloc(u8, lit.len);
+    mem.copy(u8, s, lit);
+    defer allocator.free(s);
 
-    const m1 = try s.findSubstringIndices(allocator, "i");
-    testing.expect(mem.eql(usize, m1, [_]usize{ 1, 4, 7, 10 }));
+    const m1 = try findSubStringIndices(testing.allocator, s, "i");
+    defer testing.allocator.free(m1);
+    print("{}\n", .{m1});
+    testing.expect(mem.eql(usize, m1, &[_]usize{ 1, 4, 7, 10 }));
 
-    const m2 = try s.findSubstringIndices(allocator, "iss");
-    testing.expect(mem.eql(usize, m2, [_]usize{ 1, 4 }));
+    // const m2 = try s.findSubStringIndices(allocator, "iss");
+    // testing.expect(mem.eql(usize, m2, [_]usize{ 1, 4 }));
 
-    const m3 = try s.findSubstringIndices(allocator, "z");
-    testing.expect(mem.eql(usize, m3, [_]usize{}));
+    // const m3 = try s.findSubStringIndices(allocator, "z");
+    // testing.expect(mem.eql(usize, m3, [_]usize{}));
 
-    const m4 = try s.findSubstringIndices(allocator, "Mississippi");
-    testing.expect(mem.eql(usize, m4, [_]usize{0}));
+    // const m4 = try s.findSubStringIndices(allocator, "Mississippi");
+    // testing.expect(mem.eql(usize, m4, [_]usize{0}));
 
-    var s2 = try String.init(allocator, "的中对不起我的中文不好");
-    defer s2.deinit();
-    const m5 = try s2.findSubstringIndices(allocator, "的中");
-    testing.expect(mem.eql(usize, m5, [_]usize{ 0, 18 }));
+    // var s2 = try []u8.init(allocator, "的中对不起我的中文不好");
+    // defer s2.deinit();
+    // const m5 = try s2.findSubStringIndices(allocator, "的中");
+    // testing.expect(mem.eql(usize, m5, [_]usize{ 0, 18 }));
 }
 
 test ".contains" {
-    var buf: [1024]u8 = undefined;
-    const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "Mississippi");
-    defer s.deinit();
+    const m1 = try contains(testing.allocator, "Mississippi", "i");
+    testing.expect(m1);
 
-    const m1 = try s.contains(allocator, "i");
-    testing.expect(m1 == true);
+    const m2 = try contains(testing.allocator, "Mississippi", "iss");
+    testing.expect(m2);
+    
+    const m3 = try contains(testing.allocator, "Mississippi", "z");
+    testing.expect(!m3);
 
-    const m2 = try s.contains(allocator, "iss");
-    testing.expect(m2 == true);
-
-    const m3 = try s.contains(allocator, "z");
-    testing.expect(m3 == false);
-
-    const m4 = try s.contains(allocator, "Mississippi");
-    testing.expect(m4 == true);
+    const m4 = try contains(testing.allocator, "Mississippi", "Mississippi");
+    testing.expect(m4);
 }
 
 test ".toSlice" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "hello world");
+    var s = try []u8.init(allocator, "hello world");
     defer s.deinit();
     testing.expect(mem.eql(u8, "hello world", s.toSlice()));
 }
@@ -350,7 +264,7 @@ test ".toSlice" {
 test ".toSliceConst" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "hello world");
+    var s = try []u8.init(allocator, "hello world");
     defer s.deinit();
     testing.expect(mem.eql(u8, "hello world", s.toSliceConst()));
 }
@@ -358,11 +272,11 @@ test ".toSliceConst" {
 test ".trim" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, " foo\n ");
+    var s = try []u8.init(allocator, " foo\n ");
     defer s.deinit();
     try s.trim(" \n");
     testing.expectEqualSlices(u8, "foo", s.toSliceConst());
-    testing.expect(3 == s.len());
+    testing.expect(3 == s.len);
     try s.trim(" \n");
     testing.expectEqualSlices(u8, "foo", s.toSliceConst());
 }
@@ -370,7 +284,7 @@ test ".trim" {
 test ".trimLeft" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, " foo\n ");
+    var s = try []u8.init(allocator, " foo\n ");
     defer s.deinit();
     try s.trimLeft(" \n");
     testing.expectEqualSlices(u8, "foo\n ", s.toSliceConst());
@@ -379,7 +293,7 @@ test ".trimLeft" {
 test ".trimRight" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, " foo\n ");
+    var s = try []u8.init(allocator, " foo\n ");
     defer s.deinit();
     try s.trimRight(" \n");
     testing.expectEqualSlices(u8, " foo", s.toSliceConst());
@@ -388,7 +302,7 @@ test ".trimRight" {
 test ".split" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "abc|def||ghi");
+    var s = try []u8.init(allocator, "abc|def||ghi");
     defer s.deinit();
 
     // All of these tests are from std/mem.zig
@@ -414,7 +328,7 @@ test ".split" {
 test ".replace" {
     var buf: [1024]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "Mississippi");
+    var s = try []u8.init(allocator, "Mississippi");
     defer s.deinit();
     try s.replace(allocator, "iss", "e");
     testing.expectEqualSlices(u8, "Meeippi", s.toSliceConst());
@@ -439,7 +353,7 @@ test ".replace" {
 test ".count" {
     var buf: [1024]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "Mississippi");
+    var s = try []u8.init(allocator, "Mississippi");
     defer s.deinit();
     const c1 = try s.count(allocator, "i");
     testing.expect(c1 == 4);
@@ -457,7 +371,7 @@ test ".count" {
 test ".toLower" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "ABCDEF");
+    var s = try []u8.init(allocator, "ABCDEF");
     defer s.deinit();
     s.toLower();
     testing.expectEqualSlices(u8, "abcdef", s.toSliceConst());
@@ -474,7 +388,7 @@ test ".toLower" {
 test ".toUpper" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "abcdef");
+    var s = try []u8.init(allocator, "abcdef");
     defer s.deinit();
     s.toUpper();
     testing.expectEqualSlices(u8, "ABCDEF", s.toSliceConst());
@@ -491,7 +405,7 @@ test ".toUpper" {
 test ".ptr" {
     var buf: [256]u8 = undefined;
     const allocator = &std.heap.FixedBufferAllocator.init(&buf).allocator;
-    var s = try String.init(allocator, "abcdef");
+    var s = try []u8.init(allocator, "abcdef");
     defer s.deinit();
     testing.expect(mem.eql(u8, mem.toSliceConst(u8, s.ptr()), s.toSliceConst()));
 }

--- a/string.zig
+++ b/string.zig
@@ -235,7 +235,6 @@ test "findSubstringIndices" {
     defer testing.allocator.free(m2);
     expect(mem.eql(usize, m2, &[_]usize{ 1, 4 }));
 
-    // TODO: make this pass
     const m3 = try findSubstringIndices(testing.allocator, s, "issi");
     defer testing.allocator.free(m3);
     expect(mem.eql(usize, m3, &[_]usize{ 1, 4 }));


### PR DESCRIPTION
Adds findFirstSubstring which results in a faster contains function. Changes replace to copy by slices instead of elements. Fixes a bug in the KMP algorithm that wasn't counting overlapping substrings. Changes tests to use the testing allocator.